### PR TITLE
Convert tslint rules to eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,14 +12,17 @@
         "react",
         "react-hooks",
         "jsdoc",
-        "import",
-        "prefer-arrow"
+        "import"
     ],
     "settings": {
         "react": {
             "pragma": "React",
             "version": "detect"
         }
+    },
+    "env": {
+        "es6": true,
+        "browser": true
     },
     "parserOptions": {
         "ecmaFeatures": {
@@ -41,10 +44,6 @@
             "array"
         ],
         "arrow-parens": "off",
-        "arrow-body-style": [
-            "error",
-            "as-needed"
-        ],
         "@typescript-eslint/ban-types": [
             "error",
             {
@@ -68,20 +67,38 @@
         "complexity": "off",
         "eol-last": "error",
         "guard-for-in": "error",
-        "object-curly-spacing": "error",
+        "object-curly-spacing": "off",
         "indent": [
             "error",
+            4,
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "@typescript-eslint/indent": [
+            "off",
             4
         ],
+        "react/no-unescaped-entities": "off",
+        "react/jsx-indent": [
+            "off",
+            4
+        ],
+        "react/jsx-indent-props": [
+            "off",
+            4
+        ],
+        "jsdoc/check-indentation": 1,
+        "react/no-children-prop": "off",
         "@typescript-eslint/interface-name-prefix": [
             "error",
             "never"
         ],
+        "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/prefer-interface": "off",
         "jsdoc-format": true,
         "jsdoc/check-alignment": 1,
         "jsdoc/check-examples": 1,
-        "jsdoc/check-indentation": 1,
         "jsdoc/check-param-names": 1,
         "jsdoc/check-syntax": 1,
         "jsdoc/check-tag-names": 1,
@@ -90,16 +107,10 @@
         "jsdoc/require-returns": 1,
         "jsdoc/require-returns-type": 1,
         "jsdoc/valid-types": 1,
-        "react/jsx-boolean-value": [
-            "error",
-            "always"
-        ],
-        "react/jsx-curly-spacing": [
-            "error",
-            {
-                "when": "never"
-            }
-        ],
+        "react/display-name": "off",
+        "react/prop-types": "off",
+        "react/jsx-boolean-value": "off",
+        "react/jsx-curly-spacing": "off",
         "react/jsx-equals-spacing": [
             "error",
             "never"
@@ -107,12 +118,15 @@
         "react/jsx-key": "error",
         "react/jsx-no-bind": "error",
         "react/no-string-refs": "error",
-        "react/jsx-tag-spacing": ["error", {
-            "closingSlash": "never",
-            "beforeSelfClosing": "always",
-            "afterOpening": "never",
-            "beforeClosing": "allow"
-        }],
+        "react/jsx-tag-spacing": [
+            "error",
+            {
+                "closingSlash": "never",
+                "beforeSelfClosing": "always",
+                "afterOpening": "never",
+                "beforeClosing": "allow"
+            }
+        ],
         "react/jsx-wrap-multilines": "error",
         "no-labels": "error",
         "no-unused-labels": "error",
@@ -123,18 +137,32 @@
         "max-len": [
             "error",
             {
-                "code": 160
+                "code": 160,
+                "tabWidth": 4
             }
         ],
-        "@typescript-eslint/explicit-member-accessibility": ["error", {
-            "accessibility": "explicit"
-        }],
-        "@typescript-eslint/member-ordering": ["error", {
-            "default": [
-                "public-static-field",
-                "public-instance-method"
-            ]
-        }],
+        "@typescript-eslint/explicit-member-accessibility": [
+            "error",
+            {
+                "accessibility": "explicit",
+                "overrides": {
+                    "accessors": "explicit",
+                    "constructors": "no-public",
+                    "methods": "explicit",
+                    "properties": "explicit",
+                    "parameterProperties": "off"
+                }
+            }
+        ],
+        "@typescript-eslint/member-ordering": [
+            "error",
+            {
+                "default": [
+                    "public-static-field",
+                    "public-instance-method"
+                ]
+            }
+        ],
         "new-parens": "error",
         "@typescript-eslint/no-angle-bracket-type-assertion": "error",
         "@typescript-eslint/no-explicit-any": "off",
@@ -149,11 +177,10 @@
         "constructor-super": "error",
         "no-redeclare": "error",
         "no-empty": "error",
-        "@typescript-eslint/no-empty-interface": "error",
+        "@typescript-eslint/no-empty-interface": "off",
         "no-eval": "error",
-        "import/no-internal-modules": [
-            "error"
-        ],
+        "import/no-duplicates": "off",
+        "import/no-internal-modules": "off",
         "no-invalid-this": "off",
         "@typescript-eslint/no-misused-new": "error",
         "@typescript-eslint/no-namespace": "error",
@@ -169,7 +196,9 @@
         "no-undef-init": "error",
         "no-unsafe-finally": "error",
         "no-unused-expressions": "error",
-        "no-use-before-define": "error",
+        "no-use-before-define": "off",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-object-literal-type-assertion": "off",
         "no-var": "error",
         "@typescript-eslint/no-var-requires": "error",
         "quote-props": [
@@ -186,8 +215,12 @@
                 "const": "never"
             }
         ],
-        "prefer-arrow/prefer-arrow-functions": "error",
-        "prefer-arrow-callback": "error",
+        "prefer-arrow-callback": [
+            "error",
+            {
+                "allowNamedFunctions": true
+            }
+        ],
         "sort-imports": "off",
         "prefer-const": "error",
         "@typescript-eslint/prefer-for-of": "error",
@@ -212,10 +245,7 @@
             }
         ],
         "default-case": "error",
-        "comma-dangle": [
-            "error",
-            "never"
-        ],
+        "comma-dangle": "off",
         "eqeqeq": [
             "error",
             "always",
@@ -223,12 +253,48 @@
                 "null": "ignore"
             }
         ],
-        "@typescript-eslint/explicit-function-return-type": "error",
-        "@typescript-eslint/type-annotation-spacing": ["error", {
-            "before": false,
-            "after": true
-        }],
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/type-annotation-spacing": [
+            "error",
+            {
+                "before": false,
+                "after": true,
+                "overrides": {
+                    "arrow": {
+                        "before": true,
+                        "after": true
+                    }
+                }
+            }
+        ],
+        "no-unexpected-multiline": "off",
+        "no-case-declarations": "off",
         "@typescript-eslint/unified-signatures": "error",
-        "use-isnan": "error"
+        "use-isnan": "error",
+        "import/no-unresolved": "off",
+        "import/namespace": "off",
+        "@typescript-eslint/no-inferrable-types": "off",
+        "@typescript-eslint/member-delimiter-style": [
+            "error",
+            {
+                "multiline": {
+                    "delimiter": "semi",
+                    "requireLast": true
+                },
+                "singleline": {
+                    "delimiter": "comma",
+                    "requireLast": false
+                },
+                "overrides": {
+                    "typeLiteral": {
+                        "multiline": {
+                            "delimiter": "comma",
+                            "requireLast": false
+                        }
+                    }
+                }
+            }
+        ],
+        "import/named": "off"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config",
+  "name": "eslint-config-neworbit",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config",
+  "name": "eslint-config-neworbit",
   "version": "0.0.1",
   "description": "NewOrbit standard typescript ready eslint configuration",
   "scripts": {},
@@ -29,7 +29,6 @@
     "eslint-config-react": "^1.1.7",
     "eslint-plugin-import": "^2.17.3",
     "eslint-plugin-jsdoc": "^7.2.0",
-    "eslint-plugin-prefer-arrow": "^1.1.5",
     "eslint-plugin-react": "^7.13.0",
     "eslint-plugin-react-hooks": "^1.6.0",
     "typescript": "^3.4.5"


### PR DESCRIPTION
The following resources where used to complete this migration to ESLint

https://eslint.org/docs/rules/
https://palantir.github.io/tslint/rules/
https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin/docs/rules
https://github.com/benmosher/eslint-plugin-import/tree/master/docs/rules

I then found the road map [1-to-1 map](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/ROADMAP.md)
