### PR TITLE
Change jsdoc-format rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,7 +97,7 @@
         ],
         "@typescript-eslint/camelcase": "off",
         "@typescript-eslint/prefer-interface": "off",
-        "jsdoc-format": true,
+        "jsdoc-format": 1,
         "jsdoc/check-alignment": 1,
         "jsdoc/check-examples": 1,
         "jsdoc/check-param-names": 1,


### PR DESCRIPTION
Changing to fix this error:

```
Error: .eslintrc.json » eslint-config-neworbit:
        Configuration for rule "jsdoc-format" is invalid:
        Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed 'true').
```