### PR TITLE
Add "max-lines" rule set at 500 lines

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -205,7 +205,7 @@
                 "tabWidth": 4
             }
         ],
-        "max-lines": ["error", 500],
+        "max-lines": "error",
         "new-parens": "error",
         "no-bitwise": "error",
         "no-caller": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -205,6 +205,7 @@
                 "tabWidth": 4
             }
         ],
+        "max-lines": ["error", 500],
         "new-parens": "error",
         "no-bitwise": "error",
         "no-caller": "error",


### PR DESCRIPTION
A breaking change to add the [max-lines](https://eslint.org/docs/rules/max-lines) rule to our config. Initially set at 500 lines (@OwenPattison has spoken to a number of teams and this is a value that most are happy with to begin with that will not cause too much pain) with the view to decrease this as we see fit.