### PR TITLE
add no-self-import rule which shows as an error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -162,6 +162,7 @@
         "import/no-duplicates": "off",
         "import/no-internal-modules": "off",
         "import/no-unresolved": "off",
+        "import/no-self-import": "error",
         "import/order": [
             "error",
             {


### PR DESCRIPTION
This rule acts exactly the same as old https://github.com/NewOrbit/tslint-import-own-index/issues/3 plugin.

You can read more about this rule here -> https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-self-import.md.

Closes: https://github.com/NewOrbit/eslint-config/issues/79