### PR TITLE
Missing rules for hooks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
         "plugin:@typescript-eslint/recommended",
         "plugin:react/recommended",
         "plugin:import/errors",
-        "plugin:import/warnings"
+        "plugin:import/warnings",
+        "plugin:react-hooks/recommended"
     ],
     "plugins": [
         "@typescript-eslint",


### PR DESCRIPTION
During eslint integration with CI/CD, I saw that our eslint config doesn't lint missing dependencies in hooks and basically it doesn't prevents us from breaking basic rules of hooks like using them inside if statements.

I went up in the tree and found out that we have a `eslint-plugin-react-hooks` but we miss extend eslint with react-hooks rules.

This fixes it.

Before (eslint doesn't complain about missing `dateChange` in dependency array):
![image](https://user-images.githubusercontent.com/9931428/94664651-6fca8900-030b-11eb-8edf-ef95e7b25ec8.png)

After:
![image](https://user-images.githubusercontent.com/9931428/94664816-a6a09f00-030b-11eb-96c9-d04a597119e8.png)

